### PR TITLE
Fix contact fields crashing on update due to outdated Pipfile

### DIFF
--- a/rapid_pro/Pipfile
+++ b/rapid_pro/Pipfile
@@ -8,7 +8,7 @@ verify_ssl = true
 [packages]
 coredatamodules = {editable = true,git = "https://github.com/AfricasVoices/CoreDataModules",ref = "v0.15.0"}
 pipelineinfrastructure = {editable = true,git = "https://www.github.com/AfricasVoices/Pipeline-Infrastructure",ref = "v0.0.12"}
-rapidprotools = {editable = true,git = "https://github.com/AfricasVoices/RapidProTools",ref = "create-field-field-id"}
+rapidprotools = {editable = true,git = "https://github.com/AfricasVoices/RapidProTools",ref = "v0.3.8"}
 
 [requires]
 python_version = "3.6"

--- a/rapid_pro/Pipfile.lock
+++ b/rapid_pro/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a831600e747120e527a8858453903ddf09288bd69107ea1c7694a4b2a3ac99fa"
+            "sha256": "4ad9fb58b9d39ad42646911002eb4d363fe341b0a42ef30da2286fc2ef64ad46"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -90,7 +90,7 @@
         "coredatamodules": {
             "editable": true,
             "git": "https://github.com/AfricasVoices/CoreDataModules",
-            "ref": "2e628333c0d0003015944f853e0b23bbe33eaa17"
+            "ref": "e086f64d5d9aa2a7e054096c38776191993b398d"
         },
         "firebase-admin": {
             "hashes": [
@@ -105,27 +105,27 @@
                 "grpc"
             ],
             "hashes": [
-                "sha256:67e33a852dcca7cb7eff49abc35c8cc2c0bb8ab11397dc8306d911505cae2990",
-                "sha256:779107f17e0fef8169c5239d56a8fbff03f9f72a3893c0c9e5842ec29dfedd54"
+                "sha256:15e00ceb7e6dc44159e2a41a222830744e9ebcb3a553c580b61cb5a66572f2f0",
+                "sha256:4a9d7ac2527a9e298eebb580a5e24e7e41d6afd97010848dd0f306cae198ec1a"
             ],
             "markers": "platform_python_implementation != 'PyPy'",
-            "version": "==1.22.2"
+            "version": "==1.22.4"
         },
         "google-api-python-client": {
             "hashes": [
-                "sha256:05cb331ed1aa15746f606c7e36ea51dbe7c29b1a5df9bbf58140901fe23d7142",
-                "sha256:54a7d330833a2e7b0587446d7e4ae6d0244925a9a8e1dfe878f3f7e06cdedb62"
+                "sha256:5b3f4908c041f3109135841cf7e49fc4477f26f7d02b6db72753a17f8b338d01",
+                "sha256:844ef76bda585ea0ea2d5e7f8f9a0eb10d6e2eba66c4fea0210ec7843941cb1a"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.12.2"
+            "version": "==1.12.3"
         },
         "google-auth": {
             "hashes": [
-                "sha256:31941bf019fb242c04d0de32845da10180788bfddb0de87d78c4bdf55555dda1",
-                "sha256:873051a6317294b083795cffc467bcd05b6df483ef542bfe0069ddbfbac0a096"
+                "sha256:712dd7d140a9a1ea218e5688c7fcb04af71b431a29ec9ce433e384c60e387b98",
+                "sha256:9c0f71789438d703f77b94aad4ea545afaec9a65f10e6cc1bc8b89ce242244bb"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.21.3"
+            "version": "==1.22.1"
         },
         "google-auth-httplib2": {
             "hashes": [
@@ -136,11 +136,11 @@
         },
         "google-cloud-core": {
             "hashes": [
-                "sha256:4c9e457fcfc026fdde2e492228f04417d4c717fb0f29f070122fb0ab89e34ebd",
-                "sha256:613e56f164b6bee487dd34f606083a0130f66f42f7b10f99730afdf1630df507"
+                "sha256:21afb70c1b0bce8eeb8abb5dca63c5fd37fc8aea18f4b6d60e803bd3d27e6b80",
+                "sha256:75abff9056977809937127418323faa3917f32df68490704d39a4f0d492ebc2b"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.4.1"
+            "version": "==1.4.3"
         },
         "google-cloud-firestore": {
             "hashes": [
@@ -184,11 +184,11 @@
         },
         "google-resumable-media": {
             "hashes": [
-                "sha256:173acc6bade1480a529fa29c6c2717543ae2dc09d42e9461fdb86f39502efcf2",
-                "sha256:99b5ac33a75ddb25d5e6aad487b37ecb4fa18b1fbf3d1ad726e032c3d6fc9aff"
+                "sha256:dcdab13e95bc534d268f87d5293e482cce5bc86dfce6ca0f2e2e89cbb73ef38c",
+                "sha256:ecabcd90d74a6e00331af0c87f500f238c44870d9626e01b385dda3af7b99269"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==1.0.0"
+            "version": "==1.1.0"
         },
         "googleapis-common-protos": {
             "hashes": [
@@ -392,7 +392,7 @@
         "rapidprotools": {
             "editable": true,
             "git": "https://github.com/AfricasVoices/RapidProTools",
-            "ref": "342f59380760e37770c22e9f28a5768758ee3397"
+            "ref": "350be311256ee094ed0eb14cb7cfb974fe1ad6df"
         },
         "requests": {
             "hashes": [


### PR DESCRIPTION
This fixes the issue we hit on Miranda last week when attempting to use master to sync the CSAP contact fields. The python script was fine, I just hadn't updated the dependency on RapidProTools.